### PR TITLE
ci: switch from SLSA provenance to actions/attest with subject-path

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -1,0 +1,38 @@
+name: Publish Package
+description: 'Packs DLLs into unsigned Nuget package and publishes to Nuget.'
+inputs:
+  dry_run:
+    description: 'Is this a dry run. If so no package will be published.'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup dotnet build tools
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0
+
+    - name: Create Nuget Package
+      shell: bash
+      run: |
+        dotnet restore ./src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
+        dotnet pack --no-build --output nupkgs --configuration Release ./src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
+
+    - name: Publish Package
+      if: ${{ inputs.dry_run == 'false' }}
+      shell: bash
+      run: |
+        for pkg in $(find ./nupkgs -name '*.nupkg' -o -name '*.snupkg'); do
+          echo "publishing ${pkg}"
+          dotnet nuget push "${pkg}" --api-key ${{ env.NUGET_API_KEY }} --source https://www.nuget.org
+          echo "published ${pkg}"
+        done
+
+    - name: Dry Run Publish
+      if: ${{ inputs.dry_run == 'true' }}
+      shell: bash
+      run: |
+        echo "This is a dry run and packages are not being published."
+        for pkg in $(find ./nupkgs -name '*.nupkg' -o -name '*.snupkg'); do
+          echo "detected package ${pkg}"
+        done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v4
@@ -71,16 +72,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ inputs.dry_run }}
 
-  provenance:
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    if: ${{ inputs.dry_run  == 'false' }}
-    needs: ['publish']
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
-    with:
-      base64-subjects: "${{ needs.publish.outputs.hashes }}"
-      upload-assets: true
-      upload-tag-name: ${{ inputs.tag }}
-      provenance-name: ${{ format('LaunchDarkly.Logging.Log4net-{0}_provenance.intoto.jsonl', inputs.tag) }}
+      - name: Generate checksums file
+        if: ${{ inputs.dry_run == 'false' }}
+        env:
+          HASHES: ${{ steps.publish.outputs.hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: ${{ inputs.dry_run == 'false' }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,15 +71,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ inputs.dry_run }}
 
-      - name: Generate checksums file
-        if: ${{ inputs.dry_run == 'false' }}
-        env:
-          HASHES: ${{ steps.publish.outputs.hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ inputs.dry_run == 'false' }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'nupkgs/*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
 
       - name: Attest build provenance
-        if: ${{ inputs.dry_run == 'false' }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,14 @@ on:
         type: boolean
         required: true
       tag:
-        description: 'Tag for provenance. For a dry run the value does not matter.'
+        description: 'Tag of an existing draft release. For a dry run the value does not matter.'
         type: string
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: true
 
   workflow_call:
     inputs:
@@ -22,6 +27,11 @@ on:
         description: 'Tag for provenance'
         type: string
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   publish:
@@ -84,3 +94,19 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['publish']
+    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,20 +7,12 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
-      tag:
-        description: 'Tag for provenance. For a dry run the value does not matter.'
-        type: string
-        required: true
 
   workflow_call:
     inputs:
       dry_run:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
-        required: true
-      tag:
-        description: 'Tag for provenance'
-        type: string
         required: true
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,14 +8,9 @@ on:
         type: boolean
         required: true
       tag:
-        description: 'Tag of an existing draft release. For a dry run the value does not matter.'
+        description: 'Tag for provenance. For a dry run the value does not matter.'
         type: string
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: true
 
   workflow_call:
     inputs:
@@ -27,11 +22,6 @@ on:
         description: 'Tag for provenance'
         type: string
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   publish:
@@ -56,7 +46,6 @@ jobs:
             /production/common/releasing/digicert/code_signing_cert_sha1_hash = DIGICERT_CODE_SIGNING_CERT_SHA1_HASH,
             /production/common/releasing/nuget/api_key = NUGET_API_KEY'
           s3_path_pairs: 'launchdarkly-releaser/dotnet/LaunchDarkly.Logging.snk = LaunchDarkly.Logging.snk'
-
 
       - name: Build Release
         uses: ./.github/actions/release-build
@@ -94,19 +83,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['publish']
-    if: ${{ !inputs.dry_run && inputs.publish_release }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ inputs.tag }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,4 +34,3 @@ jobs:
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
-      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,57 +23,15 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
 
-  create-tag:
-    needs: ['release-please']
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create release tag
-        env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
   ci:
     needs: ['release-please']
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/ci.yml
 
   publish:
-    needs: ['release-please', 'ci', 'create-tag']
+    needs: ['release-please', 'ci']
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag: ${{ needs.release-please.outputs.tag_name }}
-
-  publish-release:
-    needs: ['release-please', 'publish']
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-please:
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
+      release_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     permissions:
@@ -23,14 +23,57 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
 
+  create-tag:
+    needs: ['release-please']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
   ci:
     needs: ['release-please']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/ci.yml
+
   publish:
-    needs: ['release-please', 'ci']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    needs: ['release-please', 'ci', 'create-tag']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: ['release-please', 'publish']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,6 @@ jobs:
   release-please:
     outputs:
       release_created: ${{ steps.release.outputs.releases_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying SDK build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below:
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=1.0.1
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.Logging.Log4net -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.Logging.Log4net.${SDK_VERSION}/LaunchDarkly.Logging.Log4net.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.Logging.Log4net.1.0.1.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-logging-adapter-log4net
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-logging-adapter-log4net
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,17 @@ a8a17f69f1bef56e253fc9166096c907514ab74b812d041faa04712e2bcb243d
 Public Key Token: d9182e4b0afd33e7
 ```
 
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
 
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:
     * Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
     * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
     * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-    * Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
+    * Grant access to certain features based on user attributes, like payment plan (eg: users on the 'gold' plan get access to more features than users in the 'silver' plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
 * LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/docs) for a complete list.
 * Explore LaunchDarkly
     * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
       "release-type": "simple",
       "bootstrap-sha": "143b96aedaca89d7cf99955e307052e1b20627eb",
       "include-v-in-tag": false,
-      "include-component-in-tag": false,
-      "force-tag-creation": true
+      "include-component-in-tag": false
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
       "bootstrap-sha": "143b96aedaca89d7cf99955e307052e1b20627eb",
       "include-v-in-tag": false,
       "include-component-in-tag": false,
-      "draft": true,
       "force-tag-creation": true
     }
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
       "release-type": "simple",
       "bootstrap-sha": "143b96aedaca89d7cf99955e307052e1b20627eb",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "draft": true
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
       "bootstrap-sha": "143b96aedaca89d7cf99955e307052e1b20627eb",
       "include-v-in-tag": false,
       "include-component-in-tag": false,
-      "draft": true
+      "draft": true,
+      "force-tag-creation": true
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,10 @@
       "release-type": "simple",
       "bootstrap-sha": "143b96aedaca89d7cf99955e307052e1b20627eb",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        "PROVENANCE.md"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Updates the release workflow to support GitHub's immutable releases feature. Since this repo only uses attestation (no binary/artifact uploads to the release), draft releases are **not** needed — release-please publishes the release directly, and `actions/attest@v4` stores attestations via GitHub's attestation API (not as release assets).

### Changes

- **`.github/actions/publish/action.yml`** *(new)* — Added missing composite publish action (this repo previously lacked one, unlike other .NET repos). Packs the project into `nupkgs/` via `dotnet pack` and pushes `.nupkg`/`.snupkg` files to NuGet (or lists them on dry runs).
- **`.github/workflows/publish.yml`** — Replaced the SLSA provenance reusable workflow (`slsa-github-generator`) with an inline `actions/attest@v4` step using `subject-path: 'nupkgs/*'`. Added `attestations: write` permission. Removed the separate `provenance` job and its `base64-subjects`, `upload-assets`, `upload-tag-name`, and `provenance-name` inputs. Removed the unused `tag` input from both `workflow_dispatch` and `workflow_call` triggers. Uses `format('{0}', inputs.dry_run) == 'false'` for the dry_run condition to handle both boolean (`workflow_call`) and string (`workflow_dispatch`) input types.
- **`.github/workflows/release-please.yml`** — Renamed job output from `releases_created` to `release_created` (singular) and updated downstream `if:` conditions. Removed `tag_name` output (dead code after `tag` input removal). Removed `tag:` from the `publish` job's `with:` block.
- **`release-please-config.json`** — Added `PROVENANCE.md` to `extra-files` so release-please keeps the version placeholder in sync on each release.
- **`PROVENANCE.md`** *(new)* — Documents how to verify build provenance using `gh attestation verify`, with NuGet-specific download/verify instructions and sample output.
- **`README.md`** — Added SLSA framework provenance section linking to `PROVENANCE.md`.

## Review & Testing Checklist for Human

- [ ] **Verify the new composite action's pack command is correct**: The new `.github/actions/publish/action.yml` runs `dotnet pack --no-build --output nupkgs` against `./src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj`. Confirm this project path is correct and that `--no-build` works (i.e., the workflow's "Build Release" step produces artifacts that `dotnet pack --no-build` can consume). If the build output isn't in the expected location, `dotnet pack --no-build` will fail silently or produce an empty package.
- [ ] **Verify `subject-path: 'nupkgs/*'` matches actual build output**: Confirm that the composite action's `dotnet pack --output nupkgs` produces files in `nupkgs/` relative to the workspace root. If the working directory differs, attestation will silently attest zero files.
- [ ] **Verify the output key rename is safe**: The job output was renamed from `releases_created` to `release_created` (singular). The mapping still reads `${{ steps.release.outputs.releases_created }}` from the release-please action. Confirm no other workflows or external consumers depend on the old key name.
- [ ] **Dry_run condition inconsistency**: The attest step in `publish.yml` uses `format('{0}', inputs.dry_run) == 'false'` (type-safe), but the composite action's own steps use plain `inputs.dry_run == 'false'` (string-only). This is fine today because composite action inputs are always strings, but worth noting for consistency.
- [ ] **End-to-end test**: Trigger a dry-run publish and verify: (1) attestation step is correctly skipped, (2) no errors from the removed `provenance` job reference, (3) composite action lists packages without pushing. Then trigger a real release and verify attestation is stored (`gh attestation verify`) and no `.intoto.jsonl` asset appears on the release.

### Notes
- The SLSA provenance file (`.intoto.jsonl`) will no longer be uploaded as a release asset. Attestations are now stored via GitHub's native attestation API instead.
- No `draft` or `force-tag-creation` settings in `release-please-config.json` — these are only needed for repos that upload artifacts to releases, which this repo does not.
- The `format('{0}', inputs.dry_run) == 'false'` pattern ensures the dry_run check works regardless of whether the input arrives as a boolean (from `workflow_call`) or a string (from `workflow_dispatch`).
- A minor trailing whitespace fix in `README.md` is included in the diff.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84