### PR TITLE
ci: add permissions to publish caller job and upgrade release-please-action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{secrets.GITHUB_TOKEN}}
@@ -29,6 +29,11 @@ jobs:
 
   publish:
     needs: ['release-please', 'ci']
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      attestations: write
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:


### PR DESCRIPTION
## Summary
Fixes Release Please `startup_failure` by adding explicit `permissions` to the `publish` caller job. Also upgrades release-please-action from v4 to v5.

## Review & Testing Checklist for Human
- [ ] Verify the release-please workflow runs without startup_failure on next push to main

### Notes
Same fix pattern as dotnet-core PR #241. The publish caller job needs explicit permissions because publish.yml declares permissions that exceed the restricted org defaults.

Link to Devin session: https://app.devin.ai/sessions/54e32482848742c19ebf9c374efdc833
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release/publish GitHub Actions workflow behavior and expands the `publish` job’s token permissions (including `attestations: write`), which can affect release automation and security boundaries if misconfigured.
> 
> **Overview**
> Upgrades the Release Please workflow to use `googleapis/release-please-action` v5.
> 
> Adds explicit `permissions` to the `publish` caller job (including `attestations: write`) so it can successfully invoke `publish.yml` under restricted org defaults and perform OIDC/attestation steps during releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bcdc37b41a6d0663d5b81cab0a89635732f0c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->