### PR TITLE
fix: widen log4net version constraint to allow v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,13 @@ jobs:
       matrix:
           os: ['ubuntu-latest', 'windows-latest']
           dotnet: [{sdk: '8.x', test-framework: 'net8.0'}, {sdk: '9.x', test-framework: 'net9.0'}]
+          log4net-version: ['2.0.12', '3.3.0']
     runs-on: ${{ matrix.os }}
-    name: Build ${{ matrix.os }} - ${{ matrix.dotnet.sdk }} - ${{ matrix.dotnet.test-framework }}
+    name: Build ${{ matrix.os }} - ${{ matrix.dotnet.sdk }} - ${{ matrix.dotnet.test-framework }} - log4net ${{ matrix.log4net-version }}
     env:
       BUILDFRAMEWORKS: netstandard2.1
       TESTFRAMEWORK: ${{ matrix.dotnet.test-framework }}
+      LOG4NET_VERSION: ${{ matrix.log4net-version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ci

--- a/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
+++ b/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.0,]" />
-    <PackageReference Include="log4net" Version="[2.0.6,)" />
+    <PackageReference Include="log4net" Version="[2.0.6, 4.0.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
+++ b/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.0,]" />
-    <PackageReference Include="log4net" Version="[2.0.6,3.0.0)" />
+    <PackageReference Include="log4net" Version="[2.0.6,)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/test/LaunchDarkly.Logging.Log4net.Tests/LaunchDarkly.Logging.Log4net.Tests.csproj
+++ b/test/LaunchDarkly.Logging.Log4net.Tests/LaunchDarkly.Logging.Log4net.Tests.csproj
@@ -3,13 +3,14 @@
     <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">net8.0</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
     <AssemblyName>LaunchDarkly.Logging.Log4net.Tests</AssemblyName>
+    <LOG4NET_VERSION Condition="'$(LOG4NET_VERSION)' == ''">2.0.12</LOG4NET_VERSION>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="log4net" Version="$(LOG4NET_VERSION)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LaunchDarkly.Logging.Log4net.Tests/LaunchDarkly.Logging.Log4net.Tests.csproj
+++ b/test/LaunchDarkly.Logging.Log4net.Tests/LaunchDarkly.Logging.Log4net.Tests.csproj
@@ -3,7 +3,7 @@
     <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">net8.0</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
     <AssemblyName>LaunchDarkly.Logging.Log4net.Tests</AssemblyName>
-    <LOG4NET_VERSION Condition="'$(LOG4NET_VERSION)' == ''">2.0.12</LOG4NET_VERSION>
+    <LOG4NET_VERSION Condition="'$(LOG4NET_VERSION)' == ''">3.3.0</LOG4NET_VERSION>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: widen log4net version constraint to allow v3
END_COMMIT_OVERRIDE

## Summary

Replaces Dependabot PR #13 which would have bumped the minimum log4net version from 2.0.6 to 3.3.0. Instead, this widens the version constraint to allow both v2 and v3 consumers.

**What changed:**
- Package constraint: `[2.0.6,3.0.0)` → `[2.0.6,)` (preserves existing minimum, removes upper bound)
- Test default: `2.0.12` → `3.3.0` via parameterized `LOG4NET_VERSION` property
- CI matrix: now tests against both `log4net 2.0.12` and `3.3.0` on all OS/SDK combinations

**How to test:** CI matrix covers log4net v2 and v3 across ubuntu/windows × .NET 8/9.

Link to Devin session: https://app.devin.ai/sessions/8f92096ecf5f4998a6f37ca060c52891
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency range and CI/test wiring only; no runtime behavior or security-sensitive code changes.
> 
> **Overview**
> **Widens log4net compatibility** so apps on log4net v2 or v3 can reference `LaunchDarkly.Logging.Log4net` without a forced major bump.
> 
> The library’s `log4net` **PackageReference** range changes from **`[2.0.6,3.0.0)`** to **`[2.0.6, 4.0.0)`**, dropping the v3-exclusive upper cap while keeping the same minimum. Tests no longer pin **2.0.12**; they use **`$(LOG4NET_VERSION)`**, defaulting to **3.3.0** when unset. **CI** adds a matrix axis for **log4net 2.0.12** and **3.3.0** (via **`LOG4NET_VERSION`**) across existing OS and .NET SDK combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 261855f38e903b55aa6397815ea07d0cfd857e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->