### PR TITLE
chore: add release-please version markers to csproj

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "include-v-in-tag": false,
       "include-component-in-tag": false,
       "extra-files": [
+        "src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj",
         "PROVENANCE.md"
       ]
     }

--- a/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
+++ b/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!--x-release-please-start-version-->
     <Version>1.0.1</Version>
+    <!--x-release-please-end-->
     <!--
       The reason there's a mechanism here for overriding the target frameworks with
       an environment variable is that we want to be able to run CI tests using older


### PR DESCRIPTION
## Summary

release-please doesn't update the `<Version>` in the `.csproj` because the file is missing from `extra-files` and lacks `x-release-please-start-version` / `x-release-please-end` markers. This means the NuGet package would be built with the old version on every release, and `dotnet nuget push` would fail since that version already exists on NuGet.

Adds the csproj to `extra-files` in `release-please-config.json` and wraps the `<Version>` tag with release-please markers — matching how the NLog and MS logging adapters are configured.

Link to Devin session: https://app.devin.ai/sessions/746778111964463bbcfa2ddded90cb85
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation config only; no runtime or packaging logic changes beyond letting the version field be updated automatically.
> 
> **Overview**
> Configures **release-please** so it can bump the NuGet package version in `LaunchDarkly.Logging.Log4net.csproj` on each release.
> 
> Registers that `.csproj` in `release-please-config.json` `extra-files` and wraps `<Version>` with `x-release-please-start-version` / `x-release-please-end` comments, consistent with `PROVENANCE.md` and the other logging adapter projects. Without this, releases would keep building `1.0.1` and `dotnet nuget push` would fail when that version is already on NuGet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17f692798a2e5a33fd28aa8cd6d2bc6027ef0bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->